### PR TITLE
Update for Laravel 6.0 Remove deprecated helper function and use Facade

### DIFF
--- a/src/Jedrzej/Withable/WithableTrait.php
+++ b/src/Jedrzej/Withable/WithableTrait.php
@@ -1,7 +1,6 @@
 <?php namespace Jedrzej\Withable;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Input;
 use RuntimeException;
 
 trait WithableTrait
@@ -42,7 +41,7 @@ trait WithableTrait
 
     protected function getWithRelationsList($relations = null)
     {
-        return $relations ? (array)$relations : (array)Input::get($this->withParameterName, []);
+        return $relations ? (array)$relations : (array)request()->get($this->withParameterName, []);
     }
 
     /**


### PR DESCRIPTION
Update for Laravel 6.0

The Input facade, which was primarily a duplicate of the Request facade, has been removed. Use request() helper method instead of Input Class.

https://laravel.com/docs/6.0/upgrade